### PR TITLE
[zulip] Change `email` to zulip argument group

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,15 +47,17 @@ $ poetry shell
 
 ## Usage
 
-**Note:** You need the `email` and the `api_token` from the server. You can create a bot and use it for the authentication,
-please read the docs at [About bots (Zulip Help Center)](https://zulip.com/help/bots-and-integrations).
+**Note:** You need the `email` and the `api_token` (API key) from the server. You can use the user email and API key
+for authentication or create a bot and use the bot email and API key.
+
+Reference: [About bots (Zulip Help Center)](https://zulip.com/help/bots-and-integrations).
 ```
-$ perceval zulip --help
-[2021-09-11 12:50:28,594] - Sir Perceval is on his quest.
+(.venv) $ perceval zulip --help
+[2021-09-20 15:57:22,523] - Sir Perceval is on his quest.
 usage: perceval [-h] [--category CATEGORY] [--tag TAG] [--filter-classified] -t API_TOKEN
                 [--archive-path ARCHIVE_PATH] [--no-archive] [--fetch-archive]
                 [--archived-since ARCHIVED_SINCE] [--no-ssl-verify] [-o OUTFILE]
-                [--json-line] [-e EMAIL]
+                [--json-line] -e EMAIL
                 url stream
 
 positional arguments:
@@ -64,17 +66,23 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
-  -e EMAIL, --email EMAIL
-                        Zulip bot email
 
 authentication arguments:
   -t API_TOKEN, --api-token API_TOKEN
                         backend authentication token / API key
+
+zulip arguments:
+  -e EMAIL, --email EMAIL
+                        Zulip bot/user email
 ```
 
-Fetch messages from the `importlib` stream of the [Python Zulip Server](https://python.zulipchat.com)
+Fetch messages from the `importlib` stream of the [Python Zulip Server](https://python.zulipchat.com) with the
+bot email `bot@zulipchat.com` and API key `xxxx`
 ```
-$ perceval zulip https://python.zulipchat.com importlib -e bot@zulipchat.com -t xxxx
+(.venv) $ perceval zulip https://python.zulipchat.com importlib -e bot@zulipchat.com -t xxxx
+[2021-09-20 15:59:24,593] - Sir Perceval is on his quest.
+{
+...
 ```
 
 ## Contributing

--- a/perceval/backends/zulip/zulip.py
+++ b/perceval/backends/zulip/zulip.py
@@ -49,14 +49,14 @@ class Zulip(Backend):
 
     :param url: URL of the Zulip chat server
     :param stream: stream from which the messages are to be fetched
-    :param email: bot email
-    :param api_token: key needed to use the API
+    :param email: bot/user email
+    :param api_token: bot/user API key
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     :param ssl_verify: enable/disable SSL verification
     """
 
-    version = '0.1.0'
+    version = '0.1.1'
 
     CATEGORIES = [CATEGORY_MESSAGE]
 
@@ -170,7 +170,7 @@ class Zulip(Backend):
         ts = float(item['timestamp'])
         return ts
 
-    @ staticmethod
+    @staticmethod
     def metadata_category(item):
         """Extracts the category from a Zulip item.
 
@@ -193,8 +193,8 @@ class ZulipClient(HttpClient):
 
     :param url: URL of the Zulip chat server
     :param stream: stream from which the messages are to be fetched
-    :param email: bot email
-    :param api_token: key needed to use the API
+    :param email: bot/user email
+    :param api_token: bot/user API key
     :param archive: archive to store/retrieve items
     :param from_archive: it tells whether to write/read the archive
     :param ssl_verify: enable/disable SSL verification
@@ -245,10 +245,13 @@ class ZulipCommand(BackendCommand):
         action = parser.parser._option_string_actions['--api-token']
         action.required = True
 
-        # # Required arguments
+        # Zulip options
+        group = parser.parser.add_argument_group('zulip arguments')
+        group.add_argument('-e', '--email', dest='email', required=True,
+                           help="Zulip bot/user email")
+
+        # Required arguments
         parser.parser.add_argument('url', help="Zulip chat URL")
         parser.parser.add_argument('stream', help='Zulip chat stream name')
-        parser.parser.add_argument('-e', '--email', dest='email',
-                                   help="Zulip bot email")
 
         return parser

--- a/releases/unreleased/change-`email`-to-zulip-argument-group.yml
+++ b/releases/unreleased/change-`email`-to-zulip-argument-group.yml
@@ -1,0 +1,12 @@
+---
+title: Change `email` to zulip argument group
+category: fixed
+author: Venu Vardhan Reddy Tekula <venu@chaoss.community>
+issue: 1
+notes: >
+    The current implementation uses `token_auth` and supports 
+    `email` as an argument. But, `email` is not an optional
+    argument. The auth fails if no `email` is provided.
+
+    To handle this, the email is moved to a new zulip argument
+    group. Now, it throws an error is `email` is missing.


### PR DESCRIPTION
This PR creates the zulip argument group and adds the email to that group. The documentation is updated accordingly.

Backend version is 0.1.1

Fixes #1 